### PR TITLE
Allow specifying text content with block syntax

### DIFF
--- a/app/templates/components/tool-tip.hbs
+++ b/app/templates/components/tool-tip.hbs
@@ -1,4 +1,8 @@
-{{{text}}}
+{{#if text}}
+  {{{text}}}
+{{else}}
+  {{{yield}}}
+{{/if}}
 <div class="tip">
   <span class="heading">{{{heading}}}</span><br/><br/>
   <p>{{{tip}}}</p>


### PR DESCRIPTION
This allows:

```
{{#tool-tip position="top left" tagName="div" tip=myTipVariable}}
  Some text {{aVariable}} and more text
{{/tool-tip}}
```
